### PR TITLE
[Fix] 이미지 데이터 저장 로직 최적화

### DIFF
--- a/src/helper/convertImageDataToURL.ts
+++ b/src/helper/convertImageDataToURL.ts
@@ -1,41 +1,20 @@
-// export function convertImageDataToURL(imageData: ImageData[] | ImageData) {
-//   if (!imageData) return null;
-//   if (!Array.isArray(imageData)) {
-//     imageData = [imageData];
-//   }
-
-//   let maxCanvasWidth = 0;
-//   let maxCanvasHeight = 0;
-//   console.log('max 확인', maxCanvasWidth, maxCanvasHeight, imageData.length);
-//   for (let i = 0; i < imageData.length - 1; i++) {
-//     maxCanvasWidth = Math.max(maxCanvasWidth, imageData[i]?.width);
-//     maxCanvasHeight = Math.max(maxCanvasHeight, imageData[i]?.height);
-//   }
-
-//   const canvas = document.createElement('canvas');
-//   canvas.width = maxCanvasWidth;
-//   canvas.height = maxCanvasHeight;
-//   const context = canvas.getContext('2d');
-
-//   for (let e of imageData) {
-//     context.putImageData(e, 0, 0);
-//   }
-
-//   const dataURL = canvas.toDataURL();
-
-//   return dataURL;
-// }
-
-export function convertImageDataToURL(imageData: ImageData) {
+export function convertImageDataToURL(imageData: ImageData[] | ImageData) {
   if (!imageData) return null;
+  if (!Array.isArray(imageData)) {
+    imageData = [imageData];
+  }
 
   const canvas = document.createElement('canvas');
-  canvas.width = imageData.width;
-  canvas.height = imageData.height;
-  const context = canvas.getContext('2d');
 
-  context.putImageData(imageData, 0, 0);
-  const dataURL = canvas.toDataURL();
+  const resultDataUrlList = [] as string[];
 
-  return dataURL;
+  for (let e of imageData) {
+    canvas.width = e.width;
+    canvas.height = e.height;
+    const context = canvas.getContext('2d');
+    context.putImageData(e, 0, 0);
+    resultDataUrlList.push(canvas.toDataURL());
+  }
+
+  return resultDataUrlList;
 }

--- a/src/hooks/useDrawPathRef.ts
+++ b/src/hooks/useDrawPathRef.ts
@@ -1,0 +1,22 @@
+import { useRef } from 'react';
+import { memoLimitAtom } from 'recoil/memo';
+import { useRecoilValue } from 'recoil';
+
+function useDrawPathRef() {
+  const drawPathLimit = useRecoilValue(memoLimitAtom);
+  const drawPathRef = useRef<ImageData[]>([]);
+
+  const pushNewImageData = (imageData: ImageData) => {
+    if (drawPathRef.current.length >= drawPathLimit) {
+      const sliced = drawPathRef.current.slice(1);
+      sliced.push(imageData);
+      drawPathRef.current = sliced;
+    } else {
+      drawPathRef.current.push(imageData);
+    }
+  };
+
+  return { drawPathRef, pushNewImageData };
+}
+
+export default useDrawPathRef;

--- a/src/recoil/memo.ts
+++ b/src/recoil/memo.ts
@@ -18,6 +18,11 @@ export const memoLengthAtom = atom<number>({
   default: 0,
 });
 
+export const memoLimitAtom = atom<number>({
+  key: 'memoLimitAtom',
+  default: 30,
+});
+
 export const useSetMemoImpossible = () => {
   const [_, setCanSaveMemo] = useRecoilImmerState(memoCanvasAtom);
   setCanSaveMemo((draft) => {


### PR DESCRIPTION
1. 그릴 때 저장되는 drawPath를 매번 저장하는 것이 아닌, 특정 limit까지 저장하도록 수정하였습니다.

2. 이 때에, 반응형으로 캔버스 크기가 달라진 후 그림을 그리면 기존 최대사이즈의 이미지를 기록해둘 필요성이 존재하므로, 로컬 path 저장 로직과 indexedDB 기록 로직을 연동하고 저장될 데이터를 필터링 및 압축하였습니다.

3. 또한 반응형으로 client 사이즈가 줄어들 때마다, 모든 데이터를 캔버스에 re-draw하지않고, 가장 크기에 맞는 최적화된 이미지만 랜더링하도록 로직을 변경하였습니다.