### PR TITLE
[Hotfix] Global Theme으로 인해 레이아웃 깨지는 현상 해결

### DIFF
--- a/src/styles/global.tsx
+++ b/src/styles/global.tsx
@@ -1,7 +1,15 @@
-import { Global, Theme, css, useTheme } from '@emotion/react';
+import { Global, css, useTheme } from '@emotion/react';
 import { genMedia } from './theme';
+import { useEffect } from 'react';
 
 function GlobalStyle() {
+  const theme = useTheme();
+
+  useEffect(() => {
+    const html = document.querySelector('html');
+    html.style.backgroundColor = theme.backgroundColor;
+  }, [theme]);
+
   const globalCSS = css`
     :root {
       --zIndex-1st: 10000;


### PR DESCRIPTION
darkmode 확인 중, theme의 변경에 따라 html의 백그라운드도 같이 변경되고 있는데, 이로 인해서 전체 Global theme이 변경되고 자식들이 모두 리랜더링되면서 레이아웃이 깨지며 깜빡임이 벌어지는 문제가 있었습니다.

해당 로직을 globalCSS와 분리하고, 비동기적으로 html 백그라운드가 변경되도록 수정하였습니다.