### PR TITLE
[Fix] 캔버스 터치이벤트 이상작동 수정

### DIFF
--- a/src/components/CanvasMenu.tsx
+++ b/src/components/CanvasMenu.tsx
@@ -3,28 +3,37 @@ import MenuBtn from './Button/MenuBtn';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import ColorPicker from './ColorPicker';
+import { useRecoilValue } from 'recoil';
+import { memoCanvasAtom } from 'recoil/memo';
 
 function CanvasMenu() {
+  const { isCanvasOpen } = useRecoilValue(memoCanvasAtom);
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
-    <Container>
+    <Container isCanvasOpen={isCanvasOpen}>
       <MenuBtn className={menuOpen && 'active'} onClick={() => setMenuOpen((prev) => !prev)} />
 
-      <MenuBox>
-        <ColorPicker />
-      </MenuBox>
+      {menuOpen && (
+        <MenuBox>
+          <ColorPicker />
+        </MenuBox>
+      )}
     </Container>
   );
 }
 
-const Container = styled.div`
+const Container = styled.div<{ isCanvasOpen: boolean }>`
   position: fixed;
   top: calc(var(--header-height) + 1rem);
   right: var(--option-btn-right);
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+
+  transition: opacity 0.1s ease-in, visibility 0.1s ease-in;
+  opacity: ${({ isCanvasOpen }) => (isCanvasOpen ? 1 : 0)};
+  visibility: ${({ isCanvasOpen }) => (isCanvasOpen ? 'visible' : 'hidden')};
 `;
 
 const MenuBox = styled.div``;


### PR DESCRIPTION
기존 터치이벤트 시 캔버스 드로잉을 위해 터치 스크롤을 막으려고 사용한 옵션은 아래와 같습니다

    1. onTouchMove 핸들러 안에서 e.preventDefault();
    2. addEventListener형식으로 핸들로 등록 및 {passive:false} 옵션 적용.

해당 방식으로 스크롤을 막을 경우, 모바일 환경의 부드러운 스크롤을 위한 옵션
을 꺼버리게 되므로(passive:false) 이상 작동을 하는 경우가 잦음을 확인했습니다.

따라서 해당 옵션을 버리고 css로 동일한 작동을 하는 "touch-action"을 조건부로 설정하도록 수정하였습니다.