### PR TITLE
[Fix] 펜 타블렛에서 발생하는 오류들 수정Feature

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -134,7 +134,6 @@ const ColorPicker = () => {
     },
     onTouchMove(event) {
       if (isColorBarPressed) {
-        event.preventDefault();
         handlePointerHeightForMobile(event);
       }
     },
@@ -144,7 +143,7 @@ const ColorPicker = () => {
       }
     },
   };
-  colorBarCanvasRef.current?.addEventListener('touchmove', colorBarMethods.onTouchMove as any, { passive: false });
+  // colorBarCanvasRef.current?.addEventListener('touchmove', colorBarMethods.onTouchMove as any, { passive: false });
 
   useEffect(() => {
     initPicker();
@@ -186,6 +185,7 @@ const ColorPicker = () => {
           onMouseUp={colorBarMethods.onMouseUp}
           onMouseLeave={colorBarMethods.onMouseUp}
           onTouchStart={colorBarMethods.onTouchStart}
+          onTouchMove={colorBarMethods.onTouchMove}
           onTouchEnd={colorBarMethods.onTouchEnd}
           onTouchCancel={colorBarMethods.onTouchEnd}
         />
@@ -205,14 +205,18 @@ const PickerCanvasFrame = styled.div<{ background: string }>`
   margin-right: 1rem;
   background: ${({ background }) => background};
 `;
-const PickerCanvas = styled.canvas``;
+const PickerCanvas = styled.canvas`
+  touch-action: none;
+`;
 
 const ColorBarCanvasFrame = styled.div`
   width: 2rem;
   height: 100%;
   position: relative;
 `;
-const ColorBarCanvas = styled.canvas``;
+const ColorBarCanvas = styled.canvas`
+  touch-action: none;
+`;
 
 const ColorBarPointer = styled.div<{ pointerHeight: number }>`
   width: 100%;

--- a/src/components/Content/index.tsx
+++ b/src/components/Content/index.tsx
@@ -158,7 +158,7 @@ const Container = styled.div`
 
   & .fadeIn {
     animation-name: ${({ theme }) => theme.animations.fadeIn};
-    animation-duration: 2.5s;
+    animation-duration: 2s;
     animation-delay: 0.22s;
     animation-timing-function: cubic-bezier(0, 0.95, 0.48, 0.94);
     animation-fill-mode: both;

--- a/src/components/MemoCanvas.tsx
+++ b/src/components/MemoCanvas.tsx
@@ -5,6 +5,9 @@ import React, { CanvasHTMLAttributes } from 'react';
 import useCanvasDrawing from 'hooks/useCanvasDrawing';
 import { useSelector } from 'redux/store';
 import CanvasMenu from './CanvasMenu';
+import { useRecoilValue } from 'recoil';
+import { menuConfigAtom } from 'recoil/memo';
+import { checkMobile } from 'helper/checkMobile';
 
 function MemoCanvas() {
   // todo 텍스트 넣기 기능 추가
@@ -14,7 +17,9 @@ function MemoCanvas() {
   // ctrl + Z (진짜 ctrl+z도 되고, 버튼으로도 되고)
   // 전부 지우기
 
+  const isMobile = checkMobile();
   const memo = useSelector((state) => state.user.memo); //사용자별 영속성이어야 하기에 Redux-persist로 로컬관리
+  const { mode } = useRecoilValue(menuConfigAtom);
 
   const {
     isCanvasOpen,
@@ -31,15 +36,16 @@ function MemoCanvas() {
 
   const isMemoShown = (memo.isMemoShown && drawPathLength !== 0) || isCanvasOpen;
   const canvasAttrs = {
+    onMouseDown: isMobile && mode === 'pen' ? (e) => e.preventDefault() : startDrawing, //pen 이벤트는 마우스 이벤트를 공유하기에, 조건을 걸어서 시작을 막아야 함.
     onMouseMove: onDrawing,
-    onMouseDown: startDrawing,
     onMouseUp: stopDrawing,
     onMouseLeave: onMouseLeave,
-    onTouchStart: startDrawingForMobile,
-    onTouchMove: onDrawingForMobile as any,
-    onTouchEnd: stopDrawingForMobile,
-    onTouchCancel: stopDrawingForMobile,
-    onContextMenu: (e) => e.preventDefault(),
+    onPointerDown: startDrawingForMobile,
+    onPointerMove: onDrawingForMobile,
+    onPointerUp: stopDrawingForMobile,
+    onContextMenu: (e) => e.preventDefault(), // 우클릭 막기
+    onDoubleClick: (e) => e.preventDefault(), // 더클블릭 막기
+    onTouchStart: (e) => e.preventDefault(), // 터치 이벤트 시작점 막기(어차피 pointer에서 터치 처리중이고, 막아놔야 더블터치 이벤트 감지 막을 수 있다.)
   } as CanvasHTMLAttributes<HTMLCanvasElement>;
 
   return (

--- a/src/recoil/memo.ts
+++ b/src/recoil/memo.ts
@@ -6,6 +6,13 @@ export interface memoCanvasAtom {
   isCanvasOpen: boolean;
   canSaveMemo: boolean;
 }
+
+export interface MenuConfigAtom {
+  tool: 'pen' | 'ereaser';
+  mode: 'pen' | 'touch';
+  pressure: boolean;
+}
+
 export const memoCanvasAtom = atom<memoCanvasAtom>({
   key: 'memoCanvasAtom',
   default: {
@@ -31,6 +38,15 @@ export const memoContextAttrAtom = atom<Partial<CanvasRenderingContext2D>>({
     lineWidth: 2,
     lineCap: 'round',
     lineJoin: 'round',
+  },
+});
+
+export const menuConfigAtom = atom<MenuConfigAtom>({
+  key: 'menuConfigAtom',
+  default: {
+    tool: 'pen',
+    mode: 'pen',
+    pressure: false,
   },
 });
 


### PR DESCRIPTION
캔버스에서 발생할 수 있는 이벤트 타입인 "mouse","touch","pen"을 핸들링하는
이벤트 리스너들이 서로 중첩되어 오류가 발생할 수 있음을 발견했습니다.

이에 따라 최대한 경우의 수를 제약하기 위해 통합 이벤트 리스너에서 이벤트들을 관리하도록 수정하였습니다.(pointer핸들러)

또한, 아이패드에서 스크롤이 발생할 시 윈도우 사이즈가 변경되는 케이스가 있어, resize 이벤트 리스닝은 오로지 웹일 때만 적용될 수 있도록 수정하였습니다. (추후 보완 필요. 현재로서는 아이패드의 landScape모드가 된다 하더라도 기능상 지장이 없음을 확인)