### PR TITLE
[Feature] 컬러피커 캔버스 포인터 조절 로직 추가

### DIFF
--- a/src/components/MemoCanvas.tsx
+++ b/src/components/MemoCanvas.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import React, { CanvasHTMLAttributes } from 'react';
+import React, { CanvasHTMLAttributes, useLayoutEffect } from 'react';
 
 import useCanvasDrawing from 'hooks/useCanvasDrawing';
 import { useSelector } from 'redux/store';
@@ -43,10 +43,13 @@ function MemoCanvas() {
     onPointerDown: startDrawingForMobile,
     onPointerMove: onDrawingForMobile,
     onPointerUp: stopDrawingForMobile,
-    onContextMenu: (e) => e.preventDefault(), // 우클릭 막기
-    onDoubleClick: (e) => e.preventDefault(), // 더클블릭 막기
-    onTouchStart: (e) => e.preventDefault(), // 터치 이벤트 시작점 막기(어차피 pointer에서 터치 처리중이고, 막아놔야 더블터치 이벤트 감지 막을 수 있다.)
   } as CanvasHTMLAttributes<HTMLCanvasElement>;
+
+  useLayoutEffect(() => {
+    canvasRef.current.addEventListener('contextmenu', (e) => e.preventDefault(), { passive: false }); // 우클릭 막기
+    canvasRef.current.addEventListener('dblclick', (e) => e.preventDefault(), { passive: false }); // 더클블릭 막기
+    canvasRef.current.addEventListener('touchstart', (e) => e.preventDefault(), { passive: false }); // 터치 이벤트 시작점 막기(어차피 pointer에서 터치 처리중이고, 막아놔야 더블터치 이벤트 감지 막을 수 있다.)
+  }, []);
 
   return (
     <CanvasFrame isMemoShown={isMemoShown}>

--- a/src/recoil/memo.ts
+++ b/src/recoil/memo.ts
@@ -31,13 +31,38 @@ export const memoLimitAtom = atom<number>({
   default: 30,
 });
 
-export const memoContextAttrAtom = atom<Partial<CanvasRenderingContext2D>>({
+export const memoContextAttrAtom = atom<
+  Partial<
+    CanvasRenderingContext2D & {
+      pickerBackground: string;
+    }
+  >
+>({
   key: 'memoContextAttrAtom',
   default: {
+    pickerBackground: 'rgba(255, 0, 0, 1)',
     strokeStyle: colors.black,
     lineWidth: 2,
     lineCap: 'round',
     lineJoin: 'round',
+  },
+});
+
+export interface PickerCircle {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  selectedColor: string;
+}
+export const pickerCircleAtom = atom<PickerCircle>({
+  key: 'pickerCircleAtom',
+  default: {
+    x: 10,
+    y: 10,
+    width: 7,
+    height: 7,
+    selectedColor: 'rgba(255, 255, 255, 1)',
   },
 });
 


### PR DESCRIPTION
컬러 피커의 위에 포인터가 생기고 이를 핸들링할 수 있는 메서드들을 따로 분리하여 수정하였습니다.

처음에는 ColorPickerCanvas 위에 gradient와 pointer을 둘 다 구현하려고 하였으나, 

이렇게 할 경우 포인터가 움직일 때마다 기존 pointer을 지워야하는 케이스를 발견하였습니다.

이 때에 사용되는 메서드 "clearRect"이 캔버스 내의 모든 내용을 지우므로, 추가적으로 포인터용 캔버스를 따로 두고 포지션에 해당하는 픽셀수치 데이터를 ColorPickerCanvas 기준으로 처리하도록 수정하였습니다.