### PR TITLE
[Fix] 메모 이미지 저장 로직 최적화Feature

### DIFF
--- a/src/helper/genMergedImageData.ts
+++ b/src/helper/genMergedImageData.ts
@@ -1,0 +1,35 @@
+export function genMergedImageData(imageData: ImageData[] | ImageData) {
+  if (!imageData) return null;
+  if (!Array.isArray(imageData)) {
+    imageData = [imageData];
+  }
+
+  const { maxCanvasWidth, maxCanvasHeight } = calculateMaxSize(imageData);
+  const canvas = document.createElement('canvas');
+  canvas.width = maxCanvasWidth;
+  canvas.height = maxCanvasHeight;
+  const context = canvas.getContext('2d');
+
+  for (let e of imageData) {
+    context.putImageData(e, 0, 0);
+  }
+
+  return { mergedImageData: context.getImageData(0, 0, canvas.width, canvas.height), dataURL: canvas.toDataURL() };
+}
+
+function calculateMaxSize(imageData: ImageData[]) {
+  let maxCanvasWidth = 0;
+  let maxCanvasHeight = 0;
+
+  for (let e of imageData) {
+    if (e.width > maxCanvasWidth) {
+      maxCanvasWidth = e.width;
+    }
+
+    if (e.height > maxCanvasHeight) {
+      maxCanvasHeight = e.height;
+    }
+  }
+
+  return { maxCanvasWidth, maxCanvasHeight };
+}

--- a/src/hooks/useCanvasDrawing.ts
+++ b/src/hooks/useCanvasDrawing.ts
@@ -4,7 +4,14 @@ import { converURLToImageData } from 'helper/converURLToImageData';
 import { debounce } from 'helper/debounce';
 import React, { useEffect, useRef, useState } from 'react';
 import { useRecoilValue } from 'recoil';
-import { memoCanvasAtom, memoContextAttrAtom, memoLengthAtom, menuConfigAtom, useSetMemoImpossible } from 'recoil/memo';
+import {
+  memoCanvasAtom,
+  memoContextAttrAtom,
+  memoLengthAtom,
+  menuConfigAtom,
+  pickerCircleAtom,
+  useSetMemoImpossible,
+} from 'recoil/memo';
 import { colors } from 'styles/theme';
 import useIndexedDB, { tableEnum, indexing } from './useIndexedDB';
 import useRecoilImmerState from './useImmerState';
@@ -28,6 +35,7 @@ interface Memo {
 function useCanvasDrawing() {
   const isCanvasOpen = useRecoilValue(memoCanvasAtom).isCanvasOpen;
   const { mode } = useRecoilValue(menuConfigAtom);
+  const { selectedColor } = useRecoilValue(pickerCircleAtom);
   const isMobile = checkMobile();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const canvasCtxRef = useRef<CanvasRenderingContext2D | null>(null);
@@ -73,11 +81,13 @@ function useCanvasDrawing() {
       }); //실행 순서가 중요하여 async를 이용한 then 체이닝 적용.
   };
   const applymemoContextAttr = () => {
-    const context = canvasCtxRef.current ?? {};
+    const context = canvasCtxRef.current;
 
     Object.entries(memoContextAttr).forEach(([key, value]) => {
       context[key] = value;
     });
+
+    context.strokeStyle = selectedColor;
   };
 
   const resetDrawingData = () => {

--- a/src/recoil/memo.ts
+++ b/src/recoil/memo.ts
@@ -62,7 +62,7 @@ export const pickerCircleAtom = atom<PickerCircle>({
     y: 10,
     width: 7,
     height: 7,
-    selectedColor: 'rgba(255, 255, 255, 1)',
+    selectedColor: colors.black,
   },
 });
 


### PR DESCRIPTION
기존에는 반응형에 따라 최대 이미지를 memorize하고 이것을 indexedDB에 저장하
도록 하였습니다.

하지만, 예외적으로 사용자가 사이즈를 변경해가며 memo를 테스트해보는 케이스의 경우 저장되는 메모 갯수가 점진적으로 계속 늘어나게 되는 문제가 있었습니다.

이에 따라
1. memorized 되는 캔버스들을 계산하여 최적화된 캔버스 이미지로 변환한 뒤 저장
2. 사용자가 반응적으로 클라이언트 크기를 변경 시, 조건부로 memorized 병합 실행 후 저장

위 절차에 따라, 최종적으로 indexedDB에 저장되는 dataURL의 갯수는 2개가 되었습니다. [현재 화면 캔버스 이미지, 병합된 최대사이즈 캔버스 이미지]
