### PR TITLE
[Fix] 메모 이미지 최적화 로직 수정

### DIFF
--- a/src/components/CanvasMenu.tsx
+++ b/src/components/CanvasMenu.tsx
@@ -14,11 +14,9 @@ function CanvasMenu() {
     <Container isCanvasOpen={isCanvasOpen}>
       <MenuBtn className={menuOpen && 'active'} onClick={() => setMenuOpen((prev) => !prev)} />
 
-      {menuOpen && (
-        <MenuBox>
-          <ColorPicker />
-        </MenuBox>
-      )}
+      <MenuBox menuOpen={menuOpen}>
+        <ColorPicker />
+      </MenuBox>
     </Container>
   );
 }
@@ -36,6 +34,14 @@ const Container = styled.div<{ isCanvasOpen: boolean }>`
   visibility: ${({ isCanvasOpen }) => (isCanvasOpen ? 'visible' : 'hidden')};
 `;
 
-const MenuBox = styled.div``;
+const MenuBox = styled.div<{ menuOpen: boolean }>`
+  z-index: calc(var(--zIndex-2st) * -1);
+  ${({ menuOpen }) =>
+    menuOpen &&
+    css`
+      z-index: calc(var(--zIndex-2st));
+      opacity: 1;
+    `}
+`;
 
 export default CanvasMenu;

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -277,19 +277,19 @@ const ColorPicker = () => {
     };
 
     static onTouchStart(event: React.TouchEvent<HTMLCanvasElement>) {
-      isColorBarPressedRef.current = true;
+      isPickerCanvasPressedRef.current = true;
       handlePickerCirclePostionForMobile(event);
     }
 
     static onTouchMove(event: React.TouchEvent<HTMLCanvasElement>) {
-      if (isColorBarPressedRef.current) {
-        handlePointerHeightForMobile(event);
+      if (isPickerCanvasPressedRef.current) {
+        handlePickerCirclePostionForMobile(event);
       }
     }
 
     static onTouchEnd() {
-      if (isColorBarPressedRef.current) {
-        isColorBarPressedRef.current = false;
+      if (isPickerCanvasPressedRef.current) {
+        isPickerCanvasPressedRef.current = false;
       }
     }
   }

--- a/src/hooks/useDrawPathRef.ts
+++ b/src/hooks/useDrawPathRef.ts
@@ -3,6 +3,10 @@ import { memoLimitAtom } from 'recoil/memo';
 import { useRecoilValue } from 'recoil';
 
 function useDrawPathRef() {
+  // path 최적화
+  // 모든 path를 기록할 경우, 매 resize에 모든 이미지를 다 업데이트해야한다.
+  // 사실상 canvas에 저장되는 이미지가 전부 다 필요하지 않고, 마지막 이미지와 반응형에 따라 저장되는 그 당시 최대 크기 스냅샷만 필요하므로
+  // 최대 저장 크기 갯수만큼만 저장해두면 오버헤드가 발생하지 않는다 (최대저장갯수 크기는 추후 되돌리기 기능을 위함)
   const drawPathLimit = useRecoilValue(memoLimitAtom);
   const drawPathRef = useRef<ImageData[]>([]);
 


### PR DESCRIPTION
최적화를 위해서 기존 indexedDB에 저장되던 데이터를 하나로 압축하는
로직을 작성하였습니다.

이 과정 중에 메모 데이터가 제대로 반영되지 않는 문제가 발생하여
이 내용을 수정하였습니다.

원인은 아래와 같습니다
1. 메모라이징된 스냅샷 데이터는 기존 화면까지만 존재
2. 배열에 최신 스냅샷이 들어가고 메모라이징 된 값이 들어오면 최신 스냅샷을 덮음