### PR TITLE
[Fix] IOS 컬러피커 캔버스 터치 스크롤 오작동 문제 해결

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -5,6 +5,7 @@ import useRecoilImmerState from 'hooks/useImmerState';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { memoContextAttrAtom, pickerCircleAtom } from 'recoil/memo';
+import { CustomEventListner } from 'types';
 
 const ColorPicker = () => {
   const isMobile = checkMobile();
@@ -323,6 +324,19 @@ const ColorPicker = () => {
     window.addEventListener('resize', updateRects);
     return () => {
       window.removeEventListener('resize', updateRects);
+    };
+  }, []);
+
+  useEffect(() => {
+    const listener = (e: any) => {
+      e.preventDefault();
+      ColorBarHandlers.onTouchMove(e);
+    };
+    colorBarCanvasRef.current.addEventListener('touchmove', listener, { passive: false });
+
+    return () => {
+      const removeEventListener = colorBarCanvasRef.current.removeEventListener as CustomEventListner;
+      removeEventListener('touchmove', listener, { passive: false });
     };
   }, []);
 

--- a/src/components/MemoCanvas.tsx
+++ b/src/components/MemoCanvas.tsx
@@ -48,7 +48,6 @@ function MemoCanvas() {
   useLayoutEffect(() => {
     canvasRef.current.addEventListener('contextmenu', (e) => e.preventDefault(), { passive: false }); // 우클릭 막기
     canvasRef.current.addEventListener('dblclick', (e) => e.preventDefault(), { passive: false }); // 더클블릭 막기
-    canvasRef.current.addEventListener('touchstart', (e) => e.preventDefault(), { passive: false }); // 터치 이벤트 시작점 막기(어차피 pointer에서 터치 처리중이고, 막아놔야 더블터치 이벤트 감지 막을 수 있다.)
   }, []);
 
   return (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,5 @@
+export type CustomEventListner = <K extends keyof HTMLElementEventMap>(
+  type: K,
+  listener: (this: HTMLCanvasElement, ev: HTMLElementEventMap[K]) => any,
+  options?: boolean | AddEventListenerOptions,
+) => void;


### PR DESCRIPTION
실기기 애플 기반 디바이스에서 테스트한 결과  컬러피커 바를 선택할 때 touch-action만으로는 스크롤이 막아지지 않았습니다. 이에 따라, 해당 동작을 막기 위하여 eventListener을 추가하였습니다.