### PR TITLE
[Refactor] 메모 비동기 로직 리펙토링

### DIFF
--- a/src/recoil/memo.ts
+++ b/src/recoil/memo.ts
@@ -33,7 +33,7 @@ export const memoLengthAtom = atom<number>({
 
 export const memoLimitAtom = atom<number>({
   key: 'memoLimitAtom',
-  default: 30,
+  default: 20,
 });
 
 export const memoContextAttrAtom = atom<Partial<CanvasRenderingContext2D>>({


### PR DESCRIPTION
메모 저장 사이즈 로직을 최적화 한 덕택에, 더이상 resize에 대하여 drawPath 업데이트를 비동기로 처리할 필요가 없어졌습니다.

이에 따라 동기적인 업데이트로 수정함과 동시에 drawPath가 ref값이므로 발생하는 리랜더링 이슈를 비동기 로직의 의미적인 분리와 선언형 로직으로 전환하여 해결하였습니다.

또한, 불필요한 if문으로 인해 가독성이 낮아지기 때문에 논리연산자로 의미적으로 동일한 처리가 가능한 부분은 교체하였습니다.