### PR TITLE
[Feature] 지우개 모바일 디바이스 핸들링 기능 추가 및 리펙토링

### DIFF
--- a/src/components/CanvasMenu.tsx
+++ b/src/components/CanvasMenu.tsx
@@ -53,8 +53,8 @@ function CanvasMenu() {
             <MenuToolSizeSlider
               SliderIcon={BsFillEraserFill}
               labelText="지우개 크기"
-              min={1}
-              max={5}
+              min={7}
+              max={30}
               value={menuConfig.eraserSize}
               onChange={(e) => onChangeSize(e, 'eraser')}
               step={0.0001}

--- a/src/components/MemoCanvas.tsx
+++ b/src/components/MemoCanvas.tsx
@@ -29,6 +29,7 @@ function Index() {
     onDrawing,
     startDrawing,
     stopDrawing,
+    saveDrawing,
     onMouseLeave,
     startDrawingForMobile,
     onDrawingForMobile,
@@ -56,7 +57,7 @@ function Index() {
       <CanvasFrame isShown={isMemoShown}>
         <CanvasMenu />
 
-        <EraserCanvas ref={canvasRef} />
+        <EraserCanvas ref={canvasRef} saveDrawing={saveDrawing} />
         <MemoCanvas ref={canvasRef} {...(isCanvasOpen && canvasAttrs)} isCanvasOpen={isCanvasOpen} />
       </CanvasFrame>
     </>

--- a/src/components/Slider/Molecule/MenuToolSize.tsx
+++ b/src/components/Slider/Molecule/MenuToolSize.tsx
@@ -43,6 +43,7 @@ const SliderIconBox = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  color: ${colors.black};
 `;
 
 const SliderArea = styled.div`

--- a/src/hooks/useCanvasDrawing.ts
+++ b/src/hooks/useCanvasDrawing.ts
@@ -34,7 +34,7 @@ interface Memo {
 
 function useCanvasDrawing() {
   const isCanvasOpen = useRecoilValue(memoCanvasAtom).isCanvasOpen;
-  const { currentTool, drawType, penSize } = useRecoilValue(menuConfigAtom);
+  const { drawType, penSize } = useRecoilValue(menuConfigAtom);
   const { selectedColor } = useRecoilValue(pickerCircleAtom);
   const isMobile = checkMobile();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -306,6 +306,7 @@ function useCanvasDrawing() {
     onDrawing,
     startDrawing,
     stopDrawing,
+    saveDrawing,
     onMouseLeave,
     startDrawingForMobile,
     onDrawingForMobile,

--- a/src/hooks/useUpdateCanvasSize.ts
+++ b/src/hooks/useUpdateCanvasSize.ts
@@ -4,6 +4,7 @@ export const useUpdateCanvasSize = (
   canvasRef: React.MutableRefObject<HTMLCanvasElement>,
   canvasCtxRef: React.MutableRefObject<CanvasRenderingContext2D>,
   isMobile: boolean,
+  dependencies: any[] = [],
 ) => {
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -22,5 +23,5 @@ export const useUpdateCanvasSize = (
         window.removeEventListener('resize', updateCanvasSize);
       };
     }
-  }, [isMobile]);
+  }, [isMobile, ...dependencies]);
 };


### PR DESCRIPTION
모바일 터치 및 펜 디스플레이에도 지우개 기능이 작동할 수 있도록 기능을 추가하였습니다.

덧붙여, 기존 캔버스들의 핸들러가 그냥 함수 컴포넌트 내에 귀속되어 가독성이 몹시 떨어지고 확장성도 부족하다는 판단이 들었기 때문에 해당 핸들러들을 클래스로 구현하고, extends를 통하여 자바스크립트 유사상속 기능으로 클래스를 확장해 모바일 디바이스 핸들러를 구현하였습니다.

위와 같은 변경 이후 가지는 장점은 아래와 같습니다.

1. 모든 핸들러를 하나의 클래스로 구현하였기 때문에 관심사의 분리가 이루어졌고, 이를 통해 모듈로서 사용하여 재사용성에 용이해졌습니다.

2. 핸들러를 생성하는 메서드를 분리 구현하여, 클래스의 초기화에 대한 관심사를 분리하였고 이를 통해 웹과 모바일 기기 사이간의 이벤트 핸들러에 대해서 추가 연산로직이나 검증 기능을 넣기에 용이해졌습니다.

추후, 다른 캔버스 ("memo", "colorpicker") 에 존재하는 이벤트 핸들러들 역시 위와 같이 클래스 형태로 리펙토링 할 예정입니다.