### PR TITLE
[Fix] 메뉴 컴포넌트 스태킹 컨텍스트 문제 해결

### DIFF
--- a/src/components/Button/organism/ClearBtn.tsx
+++ b/src/components/Button/organism/ClearBtn.tsx
@@ -1,12 +1,6 @@
 import React, { useState } from 'react';
 import Option from '../Molecule/Option';
-import {
-  isClearMemoNoticeModalOpenAtom,
-  isClearMemoTriggeredAtom,
-  memoCanvasAtom,
-  memoLengthAtom,
-  menuConfigAtom,
-} from 'recoil/memo';
+import { isClearMemoNoticeModalOpenAtom, isClearMemoTriggeredAtom, memoCanvasAtom, memoLengthAtom } from 'recoil/memo';
 import useRecoilImmerState from 'hooks/useImmerState';
 import { GrClearOption } from 'react-icons/gr';
 import { css } from '@emotion/react';
@@ -41,6 +35,8 @@ function ClearBtn() {
   };
 
   const onOptionClick = async () => {
+    if (!memoLength) return;
+
     const noticeIgnoreTime = await getValue<number | undefined>({
       tableName: tableEnum.userConfig,
       key: IGNORETIME_KEY,

--- a/src/components/Button/organism/MenuBtn.tsx
+++ b/src/components/Button/organism/MenuBtn.tsx
@@ -14,6 +14,7 @@ function MenuBtn(props: HTMLAttributes<HTMLButtonElement>) {
 }
 
 const additionalCSS = css`
+  z-index: var(--zIndex-1st);
   &.active {
     transform: scale(1);
     opacity: 1;

--- a/src/components/EraserCanvas.tsx
+++ b/src/components/EraserCanvas.tsx
@@ -3,7 +3,6 @@ import React, { Ref, RefObject, forwardRef, useEffect, useRef, useState } from '
 import { CanvasFrame as BaseCanvasFrame, Canvas as BaseCanvas } from './Canvas/Atom/BaseCanvas';
 import { useRecoilValue } from 'recoil';
 import { MenuConfigAtom, memoCanvasAtom, memoLengthAtom, menuConfigAtom } from 'recoil/memo';
-import { useSelector } from 'redux/store';
 import { checkMobile } from 'helper/checkMobile';
 import { css } from '@emotion/react';
 import { useUpdateCanvasSize } from 'hooks/useUpdateCanvasSize';
@@ -32,7 +31,7 @@ const EraserCanvas = forwardRef<MemoCanvasRefType, EraserCanvasProps>(({ saveDra
   }, [memoCanvasRef]);
 
   const { onMouseDown, onMouseMove, onMouseUp, onPointerDown, onPointerMove, onPointerUp } =
-    EraserHandlersSupportingMobile.initWidthMobileHandlers({
+    EraserHandlersSupportingMobile.initWithMobileHandlers({
       refs: { eraserCanvasRef, eraserCanvasCtxRef, memoCanvasRef, memoCanvasCtxRef, eraseLastCoords },
       states: { isCanvasOpen, isEraserDown, menuConfig },
       setters: { setIsEraserDown, saveDrawing },
@@ -203,7 +202,7 @@ class EraserHandlersSupportingMobile extends EraserCanvasHandlers {
     });
   };
 
-  static initWidthMobileHandlers = (props: EraserCanvasHandlersProps) => {
+  static initWithMobileHandlers = (props: EraserCanvasHandlersProps) => {
     return new EraserHandlersSupportingMobile(props);
   };
 }

--- a/src/components/MemoCanvas.tsx
+++ b/src/components/MemoCanvas.tsx
@@ -2,7 +2,6 @@ import React, { CanvasHTMLAttributes, forwardRef, useLayoutEffect } from 'react'
 
 import useCanvasDrawing from 'hooks/useCanvasDrawing';
 import { useSelector } from 'redux/store';
-import CanvasMenu from './CanvasMenu';
 import { useRecoilValue } from 'recoil';
 import { isClearMemoTriggeredAtom, menuConfigAtom } from 'recoil/memo';
 import { checkMobile } from 'helper/checkMobile';
@@ -78,7 +77,6 @@ interface MemoCanvasProps {
 }
 const MemoCanvas = forwardRef<MemoCanvasRefType, MemoCanvasProps>(({ isMemoShown, isCanvasOpen, canvasAttrs }, ref) => (
   <CanvasFrame isShown={isMemoShown}>
-    <CanvasMenu />
     <Canvas ref={ref} {...(isCanvasOpen && canvasAttrs)} isCanvasOpen={isCanvasOpen} />
   </CanvasFrame>
 ));

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -18,6 +18,7 @@ import useRecoilImmerState from 'hooks/useImmerState';
 import { indexedDBAtom } from 'recoil/IndexedDB';
 import useCheckIndexedDB from 'hooks/useCheckIndexedDB';
 import useRestoreScroll from 'hooks/useRestoreScroll';
+import CanvasMenu from 'components/CanvasMenu';
 
 const IndexPage: NextPage = () => {
   const [database, setDatabase] = useRecoilImmerState(indexedDBAtom);
@@ -34,6 +35,8 @@ const IndexPage: NextPage = () => {
         <Content />
 
         <Portal>
+          <CanvasMenu />
+
           <Options>
             <MemoShownBtn />
             <OpenCanvasBtn />


### PR DESCRIPTION
GPU를 이용한 레이어들은 각각 그 자신과 자신 이하의 레벨에만 스태킹 컨텍스트가 적용이 됩니다. 따라서 형제들끼리의 z-index는 서로 영향을 받지 않는다는 문제가 있었습니다.

Menu 컴포넌트 위에 쌓이게 되는 EraseCanvas컴포넌트는 서로 형제관계에 있기 때문에 z-index에 대한 위상이 적용되지 않아 메뉴 버튼 컴포넌트가 가려져서 지우개가 활성화되면 눌리지 않는 문제가 있었습니다.

메뉴 컴포넌트는 다른 Props를 받지 않는 의존성이 낮은 컴포넌트였기에 Portal이 적용된 컴포넌트에 삽입하여 가장 최상단의 위상에 존재하도록 수정하였습니다