### PR TITLE
[Fix] 리사이징 될 때 캔버스 잘리는 문제 추가수정

### DIFF
--- a/src/hooks/useDrawPathRef.ts
+++ b/src/hooks/useDrawPathRef.ts
@@ -14,14 +14,11 @@ function useDrawPathRef(redraw: () => void, saveDrawing: () => void) {
   const goBackwardPath = () => {
     if (drawPathRef.current.length === 1) return;
     restDrawPathRef.current.push(drawPathRef.current.pop());
-
     redraw();
     saveDrawing();
   };
 
   const goForwardPath = () => {
-    console.log(drawPathRef, restDrawPathRef);
-
     if (restDrawPathRef.current.length === 0) return;
     drawPathRef.current.push(restDrawPathRef.current.pop());
     redraw();

--- a/src/hooks/useIndexedDB.ts
+++ b/src/hooks/useIndexedDB.ts
@@ -124,7 +124,6 @@ function useIndexedDB({ dbName }: Params) {
     onError?: () => any;
   }
   const saveValue = ({ tableName, key, value, type, onSuccess, onError }: SaveValueParams) => {
-    console.log('세이브 할 때마다 db 확인해보자', database);
     if (!database) {
       console.error('no database');
       return;


### PR DESCRIPTION
되돌리기 기능을 제작하면서, 리사이징 될 때 캔버스가 잘리는 문제를 확인했습니다.
로직을 확인해보니 메모라이징되는 로직에서 착오가 있었기에 이를 수정하였고
또한 되돌리기를 할 때 불필요하게 남아있는 초기 데이터 2개를 병합하는 로직으로 바꾸어

항상 초기에는 하나의 병합된 이미지만 갖게 하도록 수정하였습니다.