### PR TITLE
[Fix] IndexedDB 비동기 초기화 순서 변경

### DIFF
--- a/src/Error/index.ts
+++ b/src/Error/index.ts
@@ -4,10 +4,11 @@
 // 부모에서 전체적으로 try~catch로 잡아버려서 단순히 에러로 죽는 것을 방지해도 상관없지만, 이렇게 되면 catch 구분에 모든 처리 로직들이 누적되어 복잡도가 올라가는 문제가 발생했다.
 // 따라서, 특정할 수 있는 에러가 존재한다면 커스텀하여 관리할 수 있도록 수정하였다.
 
-export class CustomError extends Error {
-  constructor(readonly message: string, public name: string) {
-    super(message);
+export class CustomError {
+  constructor(public readonly message: string, public readonly name: string, public readonly err: any) {
+    this.message = message;
     this.name = name;
+    this.err = err;
   }
 }
 
@@ -19,7 +20,7 @@ export const customErrHandlerGenerator = (targetErrName: string, message: string
     try {
       return targetFunc();
     } catch (err) {
-      throw new CustomError(message, targetErrName); // 받아오는 에러객체가 아닌, 커스텀 에러객체를 throw
+      throw new CustomError(message, targetErrName, err); // 받아오는 에러객체가 아닌, 커스텀 에러객체를 throw
     }
   }) as Closure;
 

--- a/src/hooks/useCanvasDrawing.ts
+++ b/src/hooks/useCanvasDrawing.ts
@@ -329,14 +329,6 @@ function useCanvasDrawing() {
     }
   }, [isMobile]);
 
-  useEffect(() => {
-    // 첫 진입시 IndexedDB가 초기화되는 것을 감지하고 그 안에 있는 데이터를 가져오는 로직
-    // useEffect 내에서 비동기 함수 호출을 위함이라 IIEF로 적용
-    (() => {
-      getLastValueFromTable<Memo>(tableEnum.memo, indexing.memo).then(initDrawPath);
-    })();
-  }, [database]);
-
   return {
     isCanvasOpen,
     canvasRef,

--- a/src/hooks/useIndexedDB.ts
+++ b/src/hooks/useIndexedDB.ts
@@ -1,5 +1,3 @@
-import { useEffect, useState } from 'react';
-import useCheckIndexedDB from './useCheckIndexedDB';
 import {
   handleCreateErr,
   handleIndexErr,
@@ -98,17 +96,16 @@ function useIndexedDB({ dbName }: Params) {
         const transaction = handleTransactionErr(() => database?.transaction(tableName, 'readonly'));
         const table = handleObjectStoreErr(() => transaction?.objectStore(tableName));
         const index = handleIndexErr(() => table?.index(indexing));
-        const openCursor = handleOpenCursorErr(() => index?.openCursor(null, 'prev'));
-
-        if (openCursor) {
-          openCursor.onsuccess = (e) => {
-            const value = openCursor.result?.value;
+        const getValueByCursor = handleOpenCursorErr(() => {
+          const cursor = index?.openCursor(null, 'prev');
+          cursor.onsuccess = (e) => {
+            const value = cursor.result?.value;
             resolve(value);
           };
-          openCursor.onerror = (e) => {
+          cursor.onerror = (e) => {
             reject(new Error('Failed to retrieve last value from object store'));
           };
-        }
+        });
       } catch (err) {
         reject({ reason: 'uncaught error', err });
       }

--- a/src/indexedDB/versionManager.ts
+++ b/src/indexedDB/versionManager.ts
@@ -38,7 +38,7 @@ export class VersionManager {
   // 함수 prams로 전달받아서 return값을 객체로 하여 클로져 구현해도 무관.
   constructor(private setDatabase: SetDatabase, private db: IDBDatabase, private oldVersion: number) {}
 
-  update() {
+  async update() {
     // break가 없는 이유는, 해당 old버전 전까지 업데이트를 끌어올려야 하기 때문임.(전부 처리되어야 함)
     // 0은 초기 db가 클라이언트 스토리지에 없었을 경우
     switch (this.oldVersion) {

--- a/src/recoil/IndexedDB.ts
+++ b/src/recoil/IndexedDB.ts
@@ -1,5 +1,17 @@
 import { atom } from 'recoil';
 
+export interface IndexedDBVersion {
+  currentVersion: null | number;
+  latestVersion: number;
+}
+export const indexedDBVersionAtom = atom<IndexedDBVersion>({
+  key: 'indexedDBVersionAtom',
+  default: {
+    currentVersion: null,
+    latestVersion: 3,
+  },
+});
+
 export const indexedDBAtom = atom<IDBDatabase | null>({
   key: 'indexedDBAtom',
   default: null,


### PR DESCRIPTION
기존에는 indexedDB의 테이블 데이터 조회를  이 데이터베이스를 사용하는 컴포넌트 내에서 useEffect를 통해 일으키도록 하였습니다. 그 이유는 해당 컴포넌트를 사용하길 원할 시점에 만드는 것이 효율적이라고 여겼기 때문입니다.

하지만, 이 초기화 시점은 indexedDB가 만들어지게 되는 비동기 시점과 서로 상충하게 되어 불필요한 에러 로그를 남기게 되었습니다. 즉, 초기 데이터베이스를 생성하는 작업이 비동기적이기 때문에 (그리고 이것이 끝나는 시점을 결정지을 수가 없다는 문제로 인해) 컴포넌트에서 테이블이 만들어지는 transaction이 끝나기도 전에 요청을 날리게 되므로 에러가 나는 것이었습니다.

await를 이용해서 작업을 멈추게 하는 방법이 있지 않을까 하는 생각에 시도해 보았습니다만, async~await 구문은 해당 함수를 호출하는 부분에서의 제어흐름에는 관여하지만, 각각 비동기 로직들에 대해서는 순서를 억제할 수 없다는 것을 깨달았기 때문입니다.

따라서, 테이블 데이터 조회 역시 db가 생성되는 비동기 작업 내에서 진행하도록 수정하였고 불필요한 에러가 사라졌습니다.