### PR TITLE
[Feature] 모드 변경 버튼 추가

### DIFF
--- a/src/components/Button/organism/EraserBtn.tsx
+++ b/src/components/Button/organism/EraserBtn.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import Option from '../Molecule/Option';
 import { memoCanvasAtom, menuConfigAtom } from 'recoil/memo';
 import useRecoilImmerState from 'hooks/useImmerState';
-import { GoPencil } from 'react-icons/go';
-import { AiOutlineCheck } from 'react-icons/ai';
 import { BsFillEraserFill } from 'react-icons/bs';
 import { css } from '@emotion/react';
 import { genMedia } from 'styles/theme';

--- a/src/components/Button/organism/ModeChangeBtn.tsx
+++ b/src/components/Button/organism/ModeChangeBtn.tsx
@@ -1,0 +1,110 @@
+import styled from '@emotion/styled';
+import React, { useEffect, useState } from 'react';
+import { TbHandFinger } from 'react-icons/tb';
+import { SlPencil } from 'react-icons/sl';
+import { colors } from 'styles/theme';
+import { IconType } from 'react-icons';
+import { css } from '@emotion/react';
+import useRecoilImmerState from 'hooks/useImmerState';
+import { menuConfigAtom } from 'recoil/memo';
+
+function ModeChangeBtn() {
+  const initialState = [
+    {
+      id: 1,
+      icon: TbHandFinger,
+      drawType: 'touch',
+      text: '터치 모드',
+    },
+    {
+      id: 2,
+      icon: SlPencil,
+      drawType: 'pen',
+      text: '펜 모드',
+    },
+  ] as const;
+  const [memoConfig, setMemoConfig] = useRecoilImmerState(menuConfigAtom);
+
+  useEffect(() => {
+    console.log(memoConfig);
+  });
+
+  return (
+    <Wrapper>
+      {initialState.map((state) => (
+        <Template
+          Icon={state.icon}
+          text={state.text}
+          active={memoConfig.drawType === state.drawType}
+          onClick={() => {
+            setMemoConfig((draft) => {
+              draft.drawType = state.drawType;
+              return draft;
+            });
+          }}
+        />
+      ))}
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  width: 100%;
+  border-radius: 1.5rem;
+  overflow: hidden;
+  margin-top: 1rem;
+  border: 1px solid ${colors.black};
+  display: flex;
+  align-items: center;
+  position: relative;
+
+  &::before {
+    content: '';
+    width: 0.1rem;
+    height: 100%;
+    background-color: ${colors.black};
+    position: absolute;
+    top: 0;
+    left: 50%;
+  }
+`;
+
+const ModeContainer = styled.div<{ active: boolean }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 0.5;
+  justify-content: center;
+
+  cursor: pointer;
+  position: relative;
+
+  & span {
+    font-size: 1rem;
+    font-weight: bold;
+  }
+
+  transition: all 0.1s ease-in;
+
+  ${({ active }) =>
+    active &&
+    css`
+      background-color: ${colors.mainColor};
+      color: white;
+    `}
+`;
+
+interface TemplateProps {
+  Icon: IconType;
+  text: string;
+  onClick: (...args: any) => any;
+  active: boolean;
+}
+const Template = ({ Icon, text, onClick, active }: TemplateProps) => (
+  <ModeContainer onClick={onClick} active={active}>
+    <Icon />
+    <span>{text}</span>
+  </ModeContainer>
+);
+
+export default ModeChangeBtn;

--- a/src/components/CanvasMenu/Configs.tsx
+++ b/src/components/CanvasMenu/Configs.tsx
@@ -5,6 +5,7 @@ import { GoPencil } from 'react-icons/go';
 import useRecoilImmerState from 'hooks/useImmerState';
 import { menuConfigAtom } from 'recoil/memo';
 import { BsFillEraserFill } from 'react-icons/bs';
+import ModeChangeBtn from 'components/Button/organism/ModeChangeBtn';
 function Configs() {
   const [menuConfig, setMenuConfig] = useRecoilImmerState(menuConfigAtom);
 
@@ -43,6 +44,8 @@ function Configs() {
         onChange={(e) => onChangeSize(e, 'eraser')}
         step={0.0001}
       />
+
+      <ModeChangeBtn />
     </Wrapper>
   );
 }


### PR DESCRIPTION
모바일 환경에서 지원할 수 있는 모드를 변경하는 버튼을 추가하였습니다.

해당 로직이 필요했던 이유는 모바일 환경에서 터치액션과 펜 액션이 서로 구분되지 않으면 불필요한 드로잉(ex 펜을 사용할 때에 터치하면 드로잉의 초기 시작점이 이상해짐(팜 리젝션을 구현해야 했음)

따라서 해당 모드에 따라 적절하게 드로잉이 관리될 수 있도록 수정하였습니다.