### PR TITLE
[Fix] 초반 사용자의 되돌리기 케이스에 대한 로직 추가

### DIFF
--- a/src/hooks/useCanvasDrawing.ts
+++ b/src/hooks/useCanvasDrawing.ts
@@ -115,12 +115,20 @@ function useCanvasDrawing() {
   const initDrawPath = async (value: Memo) => {
     const dataUrlList = value?.dataUrlList ?? [];
     const convertedImageDataList = await Promise.all(dataUrlList.map((url) => converURLToImageData(url)));
-    if (convertedImageDataList.length >= 2) {
+    const genEmptyCanvas = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = 0;
+      canvas.height = 0;
+      const context = canvas.getContext('2d');
+      return context.getImageData(0, 0, 1, 1);
+    };
+
+    if (convertedImageDataList.length) {
       const merging = genMergedImageData(convertedImageDataList);
       saveDataUrlToIndexedDb({ dataUrlList: [merging.dataURL] });
       await updateDrawPathRef(merging.mergedImageData);
     } else {
-      convertedImageDataList.length && (await updateDrawPathRef(convertedImageDataList[0]));
+      await updateDrawPathRef(genEmptyCanvas());
     }
 
     updateCanvasSize(canvasRef.current);


### PR DESCRIPTION
만약 메모가 없는 상태인, 즉 아주 최초의 사용자가 드로잉을 시도한 후 되돌리기를 할 때에 자신이 처음에 그렸던 드로잉이 되돌아 가지 않는 문제가 있었습니다.

해당 로직은 이미 메모가 있는 상황에서 그렸을 때를 상정하면 옳은 로직이지만 메모가 없는 상태였다가 바로 그렸을 경우라면 다시 되돌아가서 빈 캔버스가 되도록 만들어야 함이 사용자 측면에서 옳았습니다.

이에 따라, 초반에 들어올 때에 아무런 메모 데이터가 존재하지 않는다면 빈 캔버스를 drawPath에 저장시키는 로직을 추가하여 이를 보완하였습니다.