### PR TITLE
[Fix] 배포 환경에서 chromium 관련 에러 수정 및 테스트

### DIFF
--- a/src/pages/api/pdf.ts
+++ b/src/pages/api/pdf.ts
@@ -1,8 +1,15 @@
-import puppeteer from 'puppeteer';
+// import puppeteer from 'puppeteer';
+import chromium from 'chrome-aws-lambda';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
-  const browser = await puppeteer.launch();
+  const browser = await chromium.puppeteer.launch({
+    args: [...chromium.args, '--hide-scrollbars'],
+    // defaultViewport: chromium.defaultViewport,
+    executablePath: await chromium.executablePath,
+    headless: true,
+    ignoreHTTPSErrors: true,
+  });
   const HOST = process.env.HOST;
   try {
     const page = await browser.newPage();
@@ -17,7 +24,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       const animated = document.querySelectorAll('.animate');
       animated.forEach((el) => el.classList.add('fadeIn'));
     });
-    await page.waitForTimeout(1000);
+    await page.waitForTimeout(500);
 
     const pdfBuffer = await page.pdf({
       format: 'A4',


### PR DESCRIPTION
vercel에서 올바른 브라우저를 찾기 어렵기 때문에 puppeteer가 제대로 스크린을 복사하지 못하는 문제가 있었습니다.

구글링을 하여 올바른 브라우저를 찾아 pdf로 변환시킬 수 있도록 하는 코드를 수정하였습니다. 테스트를 더 진행해 볼 필요가 있습니다.