### PR TITLE
[Fix] pdf libnss3.so 문제 해결 중

### DIFF
--- a/src/pages/api/pdf.ts
+++ b/src/pages/api/pdf.ts
@@ -1,16 +1,22 @@
 // import puppeteer from 'puppeteer';
 import chromium from 'chrome-aws-lambda';
+import puppeteer from 'puppeteer-core';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
-  const browser = await chromium.puppeteer.launch({
-    args: [...chromium.args, '--hide-scrollbars'],
-    // defaultViewport: chromium.defaultViewport,
-    executablePath: await chromium.executablePath,
-    headless: true,
-    ignoreHTTPSErrors: true,
-  });
   const HOST = process.env.HOST;
+
+  const browser = await puppeteer.launch({
+    executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
+    args: ['--no-sandbox'],
+    // args: [...chromium.args, '--hide-scrollbars'],
+    // defaultViewport: chromium.defaultViewport,
+    // executablePath: await chromium.executablePath,
+    // headless: true,
+    // ignoreHTTPSErrors: true,
+    // ignoreDefaultArgs: ['--disable-extensions', '--no-sandbox'],
+  });
+
   try {
     const page = await browser.newPage();
     await page.goto(HOST, { waitUntil: 'networkidle0' });


### PR DESCRIPTION
현재 배포 환경에서 확인을 해 볼 수 밖에 없어서 코드 수정 후 배포를 해보는 중입니다.

배포 후 pdf 다운로드를 해봤을 때 libnss3.so라이브러리를 찾을 수 없다는 문제가 발생하였습니다.

stackOverflow에 검색을 해본 결과, 주로 Node 버전문제와 puppeteer의 버전이 맞지 않는다는 답변을 가장 많이 발견하였습니다. 이로 인해 우회 방법을 찾는 중입니다.