### PR TITLE
[Style] Iphone 실기기에서 레이아웃 깨지는 문제 해결

### DIFF
--- a/src/components/Button/organism/MenuBtn.tsx
+++ b/src/components/Button/organism/MenuBtn.tsx
@@ -14,6 +14,7 @@ function MenuBtn(props: HTMLAttributes<HTMLButtonElement>) {
 }
 
 const additionalCSS = css`
+  opacity: 1;
   z-index: var(--zIndex-1st);
   &.active {
     transform: scale(1);

--- a/src/components/CanvasMenu/Sidebar.tsx
+++ b/src/components/CanvasMenu/Sidebar.tsx
@@ -65,6 +65,7 @@ const SmallIcon = styled(SmallIconContainer)<{ reverse?: boolean; active?: boole
     z-index: 100;
     font-size: 1rem;
     opacity: 1;
+    font-weight: 500;
   }
 
   ${({ reverse, active }) => {

--- a/src/components/Modal/Atom/ModalContent.ts
+++ b/src/components/Modal/Atom/ModalContent.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { colors } from 'styles/theme';
 
 export const BaseModalContent = styled.div`
-  width: 80%;
+  width: 86%;
   height: 90%;
 
   max-width: 40rem;

--- a/src/components/Modal/organism/ClearMemoNoticeModal.tsx
+++ b/src/components/Modal/organism/ClearMemoNoticeModal.tsx
@@ -85,6 +85,7 @@ const WarningIcon = styled.div`
 
 const Title = styled.h2`
   font-weight: bold;
+  white-space: nowrap;
   color: ${colors.black};
   margin-top: 3.5rem;
 `;
@@ -93,6 +94,7 @@ const Description = styled.p`
   margin-top: 2.2rem;
   font-size: 2rem;
   text-align: center;
+  word-break: keep-all;
 `;
 
 const Buttons = styled.div`


### PR DESCRIPTION
개발자도구의 모바일 디바이스에서 확인했을 때에는 문제가 없었지만, 실제 사용하는 아이폰 기기에서 화면을 띄워봤을 경우, 폰트가 반영되는 형식이 다른지 레이아웃이 조금 깨지는 부분이 존재하였습니다(MenuBtn)

이에 따라 추가적으로 스타일링을 적용하여 레이아웃을 작은 디바이스에도 호환될 수 있도록 변경하였습니다.