### PR TITLE
[Fix] undo & redo 시 되돌리기가 제대로 되지 않던 문제 수정

### DIFF
--- a/src/helper/converURLToImageData.ts
+++ b/src/helper/converURLToImageData.ts
@@ -15,6 +15,6 @@ export function converURLToImageData(url: string | null) {
       },
       false,
     );
-    image.addEventListener('error', () => resolve(null));
+    image.addEventListener('error', () => reject(null));
   });
 }

--- a/src/hooks/useDrawPathRef.ts
+++ b/src/hooks/useDrawPathRef.ts
@@ -38,7 +38,11 @@ function useDrawPathRef(redraw: () => void, saveDrawing: () => void) {
     drawPathRef.current = value;
   };
 
-  return { drawPathRef, pushNewImageData, setDrawPathRef, goBackwardPath, goForwardPath };
+  const clearRestDrawPath = () => {
+    restDrawPathRef.current = [];
+  };
+
+  return { drawPathRef, pushNewImageData, setDrawPathRef, goBackwardPath, goForwardPath, clearRestDrawPath };
 }
 
 export default useDrawPathRef;


### PR DESCRIPTION
해당 문제의 발생은 로직 상 예상하지 못한 예외를 제대로 반영하지 못했던 까닭이었습니다.

<원인 1. 지우개로 캔버스 빈 화면을 지우려 시도해도 drawPath가 저장되는 것>

사실, 드로잉이 그려져있지 않는 화면에 대해서 지우기를 시도할 경우, 해당 작업은 무시되고 drawPath의 스냅샷 이미지 기록에 들어가지 않는 것이 타당합니다. 하지만, 구현 당시 undo, redo기능을 염두해 두지 않았기에 그냥 빈 화면에 지우기를 시도해도 이미지 스냅샷을 저장하도록 두었었는데, 이것은 drawPath의 로직을 꼬이게 만드는 문제가 있었습니다.

이에 따라 지우개로 지우기를 시도할 시, 해당 영역의 픽셀 데이터를 확인하여 지울 대상이 존재할 경우에만 이미지 삭제 및 indexedDB에 스냅샷 저장을 하도록 로직을 수정하였습니다.

<원인 2. 되돌리기를 한 후 그림을 그렸을 경우 처리가 제대로 되지 않음>

포토샵의 경우, 만약 작업내역을 이전 내역으로 돌린 후 다시 그림을 그리면 이전 내역에 저장되어 있던 스냅샷의 히스토리는 날아가고 새로운 드로잉이 작업 내역으로 추가되는 것을 확인할 수 있습니다.

이를 간과하고 로직을 작성하였더니, 되돌리기 이후 그리기를 한 다음 다시 되돌리기를 해보면 제대로 undo, redo가 작동하지 않았습니다.

이에 따라 포토샵의 작업내역을 참고로 하여 스냅샷 저장 히스토리 로직을 수정하였습니다.