### PR TITLE
[Feature] 모바일 사용자를 위한 커스텀 스크롤바 추가

### DIFF
--- a/src/components/Content/index.tsx
+++ b/src/components/Content/index.tsx
@@ -158,8 +158,8 @@ const Container = styled.div`
 
   & .fadeIn {
     animation-name: ${({ theme }) => theme.animations.fadeIn};
-    animation-duration: 1s;
-    animation-delay: 0.12s;
+    animation-duration: 1.7s;
+    animation-delay: 0.22s;
     animation-timing-function: cubic-bezier(0, 0.95, 0.48, 0.94);
     animation-fill-mode: both;
   }

--- a/src/components/MemoCanvas.tsx
+++ b/src/components/MemoCanvas.tsx
@@ -39,6 +39,7 @@ function Index() {
     clearDrawing,
     goBackwardPath,
     goForwardPath,
+    initEmptyCanvas,
     database,
   } = useCanvasDrawing();
 
@@ -68,6 +69,7 @@ function Index() {
   useLayoutEffect(() => {
     if (isClearMemoTriggered) {
       clearDrawing();
+      initEmptyCanvas();
       setIsClearMemoTriggered(false);
     }
   }, [isClearMemoTriggered]);

--- a/src/components/Scrollbar/Atom/BaseStyle.ts
+++ b/src/components/Scrollbar/Atom/BaseStyle.ts
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+
+export const BaseScrollBar = styled.div`
+  width: 300px;
+  height: 300px;
+  position: fixed;
+  top: 50%;
+  transform: translateY(-50%);
+`;
+
+export const BaseScrollTrack = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: gray;
+  position: relative;
+  display: flex;
+  justify-content: center;
+`;
+
+export const BaseScrollThumb = styled.div`
+  width: 0.8rem;
+  height: 1rem;
+  border-radius: 10px;
+`;

--- a/src/components/Scrollbar/Molecule/BaseScrollBar.tsx
+++ b/src/components/Scrollbar/Molecule/BaseScrollBar.tsx
@@ -1,0 +1,23 @@
+import React, { forwardRef } from 'react';
+import { BaseScrollBar, BaseScrollThumb, BaseScrollTrack } from '../Atom/BaseStyle';
+import styled from '@emotion/styled';
+import { MoleculeProps } from 'types';
+
+type ScrollBarRefType = HTMLDivElement | null;
+type Props = MoleculeProps<HTMLDivElement>;
+
+const Index = forwardRef<ScrollBarRefType, Props>(({ additialCSS, ...rest }: Props, ref) => {
+  return (
+    <ScrollBar ref={ref} className="scroll-bar" additialCSS={additialCSS} {...rest}>
+      <BaseScrollTrack className="scroll-track">
+        <BaseScrollThumb className="scroll-thumb" />
+      </BaseScrollTrack>
+    </ScrollBar>
+  );
+});
+
+const ScrollBar = styled(BaseScrollBar)<Props>`
+  ${({ additialCSS }) => additialCSS && additialCSS};
+`;
+
+export default Index;

--- a/src/components/Scrollbar/Molecule/HomeScroll.tsx
+++ b/src/components/Scrollbar/Molecule/HomeScroll.tsx
@@ -1,0 +1,147 @@
+import React, { HTMLAttributes, useEffect, useRef, useState } from 'react';
+import { css } from '@emotion/react';
+import { colors } from 'styles/theme';
+import { useRecoilValue } from 'recoil';
+import { memoCanvasAtom } from 'recoil/memo';
+import { checkMobile } from 'helper/checkMobile';
+import BaseScrollBar from './BaseScrollBar';
+
+function HomeScroll() {
+  const isCanvasOpen = useRecoilValue(memoCanvasAtom).isCanvasOpen;
+  const isMobile = checkMobile();
+
+  const [{ innerHeight, scrollHeight }, setDemensionInfo] = useState<{ innerHeight: number; scrollHeight: number }>({
+    innerHeight: 0,
+    scrollHeight: 0,
+  });
+
+  const CUSTOM_SCROLL_HEIGHT = innerHeight * 0.3;
+  const CUSTOM_SCROLLTHUMB_HEIGHT = (innerHeight * CUSTOM_SCROLL_HEIGHT) / scrollHeight;
+
+  const [isBarPressed, setIsBarPressed] = useState(false);
+  const [thumbOffsetY, setThumbOffsetY] = useState(0);
+  const ScrollRef = useRef<HTMLDivElement | null>(null);
+  const scrollRect = useRef<Partial<DOMRect>>({
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+  });
+  const setScrollRectRef = () => {
+    const rect = ScrollRef.current?.getBoundingClientRect();
+    rect && (scrollRect.current = rect);
+  };
+
+  const limitThumbMovementRange = (clientY: number, callback?: (...args: any) => any) => {
+    const isTopExceeded = clientY - scrollRect.current.top <= 0;
+    if (isTopExceeded) {
+      return setThumbOffsetY(0);
+    }
+
+    const isBottomExceeded = clientY + CUSTOM_SCROLLTHUMB_HEIGHT >= scrollRect.current.bottom;
+    if (isBottomExceeded) {
+      return setThumbOffsetY(scrollRect.current.bottom - scrollRect.current.top - CUSTOM_SCROLLTHUMB_HEIGHT);
+    }
+
+    callback && callback();
+  };
+
+  // 초기 스크롤 Dimension 저장
+  useEffect(() => {
+    setDemensionInfo({
+      innerHeight: window.innerHeight,
+      scrollHeight: document.documentElement.scrollHeight,
+    });
+  }, []);
+
+  // 초기 스크롤 rect 정보 저장
+  useEffect(() => {
+    setScrollRectRef();
+  }, [isCanvasOpen]);
+
+  // thumb 움직일 때마다 실제 스크롤 반응하여 움직이기
+  useEffect(() => {
+    window.scrollTo({
+      top: scrollHeight * (thumbOffsetY / CUSTOM_SCROLL_HEIGHT),
+      behavior: 'instant',
+    });
+  }, [thumbOffsetY]);
+
+  const handlers: HTMLAttributes<HTMLDivElement> = {
+    onPointerDown: (e) => {
+      setIsBarPressed(true);
+      limitThumbMovementRange(e.clientY, () => {
+        setThumbOffsetY(e.clientY - scrollRect.current.top);
+      });
+    },
+    onPointerMove: (e) => {
+      if (isBarPressed) {
+        limitThumbMovementRange(e.clientY, () => {
+          setThumbOffsetY(e.clientY - scrollRect.current.top);
+        });
+      }
+    },
+    onPointerUp: () => {
+      setIsBarPressed(false);
+    },
+    onPointerLeave: () => {
+      setIsBarPressed(false);
+    },
+  };
+
+  return (
+    <BaseScrollBar
+      additialCSS={additionalCSS({
+        isShown: isCanvasOpen && isMobile,
+        scrollHeight: CUSTOM_SCROLL_HEIGHT,
+        thumbHeight: CUSTOM_SCROLLTHUMB_HEIGHT,
+        thumbOffsetY,
+      })}
+      ref={ScrollRef}
+      {...handlers}
+    />
+  );
+}
+
+const additionalCSS = ({
+  isShown,
+  scrollHeight,
+  thumbHeight,
+  thumbOffsetY,
+}: {
+  isShown: boolean;
+  scrollHeight: number;
+  thumbHeight: number;
+  thumbOffsetY: number;
+}) => css`
+  width: 1rem;
+  height: ${scrollHeight}px;
+  visibility: hidden;
+  opacity: 0;
+  transition: all 0.2s ease-in;
+  left: 0.5rem;
+  z-index: var(--zIndex-1st);
+  touch-action: none;
+  border: 0.1rem solid ${colors.black};
+  border-radius: 10px;
+  overflow: hidden;
+
+  ${isShown &&
+  css`
+    visibility: visible;
+    opacity: 1;
+  `}
+
+  & .scroll-track {
+    background-color: ${colors.white};
+  }
+
+  & .scroll-thumb {
+    background-color: ${colors.pointColorBlue};
+    height: ${thumbHeight}px;
+    position: absolute;
+    top: ${thumbOffsetY}px;
+  }
+`;
+
+export default HomeScroll;

--- a/src/helper/checkOffsetBoundary.ts
+++ b/src/helper/checkOffsetBoundary.ts
@@ -1,0 +1,4 @@
+export function checkOffsetBoundary(
+  targetRect: Partial<{ top: number; bottom: number; left: number; right: number }>,
+  offsetCoord: { x: number; y: number },
+) {}

--- a/src/hooks/useCanvasDrawing.ts
+++ b/src/hooks/useCanvasDrawing.ts
@@ -185,6 +185,7 @@ function useCanvasDrawing() {
     canvasCtxRef.current?.clearRect(0, 0, width, height);
 
     setDrawPathRef([]);
+    clearRestDrawPath();
     drawStartCoordRef.current = { x: null, y: null };
     memoPrevImageSize.current = {
       width: 0,
@@ -366,6 +367,7 @@ function useCanvasDrawing() {
     clearDrawing,
     goBackwardPath,
     goForwardPath,
+    initEmptyCanvas,
     database,
   };
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,6 +19,7 @@ import { indexedDBAtom } from 'recoil/IndexedDB';
 import useCheckIndexedDB from 'hooks/useCheckIndexedDB';
 import useRestoreScroll from 'hooks/useRestoreScroll';
 import CanvasMenu from 'components/CanvasMenu';
+import HomeScroll from 'components/Scrollbar/Molecule/HomeScroll';
 
 const IndexPage: NextPage = () => {
   const [database, setDatabase] = useRecoilImmerState(indexedDBAtom);
@@ -36,6 +37,8 @@ const IndexPage: NextPage = () => {
 
         <Portal>
           <PortalContainer id="portal-container">
+            <HomeScroll />
+
             <CanvasMenu />
 
             <Options>


### PR DESCRIPTION
모바일 환경에서 터치와 드래그에 의한 스크롤의 분리를 위해 스크롤 이벤트를 막았던 것은 사용자 경험에 매우 좋지 않은 영향을 준다고 생각하였습니다.

따라서, 모바일 환경에서도 스크롤을 가능하게 할 수 있도록 작은 커스텀 스크롤 바를추가하여 해당 기능을 통해 메모가 활성화 되어있는 상태에서 스크롤 이동을 할 수 있도록 구현하였습니다.